### PR TITLE
Enable repo tests without Infura

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 INFURA_API_KEY=
+FORK_URL=https://cloudflare-eth.com

--- a/README.md
+++ b/README.md
@@ -131,10 +131,14 @@ Clone the repository with:
 git clone --recurse-submodules https://github.com/Uniswap/universal-router.git
 ```
 
-2. Create `.env` file with api key
+2. (Optional) Create a `.env` file with a mainnet RPC endpoint. If `INFURA_API_KEY`
+   is not provided, tests will fall back to the public `cloudflare-eth.com` RPC or
+   the value of `FORK_URL`.
 
 ```
 INFURA_API_KEY='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+# or
+FORK_URL='https://your.rpc.endpoint'
 ```
 
 3. Run yarn commands to compile and test

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,6 +5,10 @@ import '@nomicfoundation/hardhat-foundry'
 import dotenv from 'dotenv'
 dotenv.config()
 
+const INFURA_API_KEY = process.env.INFURA_API_KEY
+const DEFAULT_RPC_URL = process.env.FORK_URL || "https://cloudflare-eth.com"
+const MAINNET_RPC_URL = INFURA_API_KEY ? `https://mainnet.infura.io/v3/${INFURA_API_KEY}` : DEFAULT_RPC_URL
+
 const DEFAULT_COMPILER_SETTINGS = {
   version: '0.8.26',
   settings: {
@@ -29,24 +33,24 @@ export default {
       allowUnlimitedContractSize: false,
       chainId: 1,
       forking: {
-        url: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+        url: MAINNET_RPC_URL,
         blockNumber: 20010000,
       },
     },
     mainnet: {
-      url: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url: MAINNET_RPC_URL,
     },
     ropsten: {
-      url: `https://ropsten.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url: `MAINNET_RPC_URL`,
     },
     rinkeby: {
-      url: `https://rinkeby.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url: `MAINNET_RPC_URL`,
     },
     goerli: {
-      url: `https://goerli.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url: `MAINNET_RPC_URL`,
     },
     kovan: {
-      url: `https://kovan.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url: `MAINNET_RPC_URL`,
     },
     arbitrumRinkeby: {
       url: `https://rinkeby.arbitrum.io/rpc`,
@@ -61,7 +65,7 @@ export default {
       url: `https://mainnet.optimism.io`,
     },
     polygon: {
-      url: `https://polygon-mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url: `MAINNET_RPC_URL`,
     },
     base: {
       url: `https://developer-access-mainnet.base.org`,

--- a/test/integration-tests/shared/mainnetForkHelpers.ts
+++ b/test/integration-tests/shared/mainnetForkHelpers.ts
@@ -16,6 +16,9 @@ export const WETH = WETH9[1]
 export const DAI = new Token(1, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'Dai Stablecoin')
 export const USDC = new Token(1, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD//C')
 export const USDT = new Token(1, '0xdAC17F958D2ee523a2206206994597C13D831ec7', 6, 'USDT', 'Tether USD')
+const INFURA_API_KEY = process.env.INFURA_API_KEY
+export const MAINNET_RPC_URL = INFURA_API_KEY ? `https://mainnet.infura.io/v3/${INFURA_API_KEY}` : (process.env.FORK_URL || "https://cloudflare-eth.com")
+
 export const GALA = new Token(1, '0x15D4c048F83bd7e37d49eA4C83a07267Ec4203dA', 8, 'GALA', 'Gala')
 export const SWAP_ROUTER_V2 = '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
 export const V2_FACTORY = 0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f
@@ -96,7 +99,7 @@ export const resetFork = async () => {
     params: [
       {
         forking: {
-          jsonRpcUrl: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+          jsonRpcUrl: MAINNET_RPC_URL,
           blockNumber: 20010000,
         },
       },


### PR DESCRIPTION
## Summary
- allow Hardhat to use a configurable RPC URL with fallback
- make fork helpers use the same RPC URL
- document RPC environment variables
- provide example `.env` with defaults

## Testing
- `yarn compile`
- `yarn test:hardhat`
- `forge test --isolate`


------
https://chatgpt.com/codex/tasks/task_e_6887e0b1b630832dad9b168076af1384