### PR TITLE
Add wrap ETH tests and document attack vectors

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,21 @@
+# Tested Attack Vectors
+
+This document lists security related scenarios that have been exercised with automated tests.
+
+- **Reentrancy via WETH deposit** – A malicious WETH token tries to reenter the router during a wrap.
+  - Test location: `integration-tests/UniversalRouter.test.ts` lines 116-135.
+  - Result: router reverts with `NotAllowedReenter` proving the lock prevents reentrancy.
+
+- **PAY_PORTION over 100%** – Attempting to pay a portion greater than 100% of the router balance.
+  - Test location: `integration-tests/UniversalRouter.test.ts` lines 105-114.
+  - Result: router reverts with `InvalidBips`.
+
+- **Sweep with insufficient balance** – Sweeping tokens or ETH when the contract does not hold enough funds.
+  - Test location: `foundry-tests/UniversalRouter.t.sol`.
+  - Result: router reverts with `InsufficientToken` or `InsufficientETH`.
+
+- **WrapETH insufficient balance** – Attempting to wrap more ETH than the router owns.
+  - Test location: `foundry-tests/WrapETH.t.sol`.
+  - Result: router reverts with `InsufficientETH`. A success path is also tested.
+
+No unexpected vulnerabilities were discovered in the above scenarios.

--- a/test/foundry-tests/WrapETH.t.sol
+++ b/test/foundry-tests/WrapETH.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {Payments} from "../../contracts/modules/Payments.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+import {WETH} from "lib/permit2/lib/solmate/src/tokens/WETH.sol";
+
+contract WrapETHTest is Test {
+    UniversalRouter router;
+    WETH weth;
+
+    function setUp() public {
+        weth = new WETH();
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(weth),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function testWrapETHInsufficientBalance() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.WRAP_ETH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(this), 1 ether);
+        vm.expectRevert(Payments.InsufficientETH.selector);
+        router.execute(commands, inputs);
+    }
+
+    function testWrapETHSuccess() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.WRAP_ETH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(this), 1 ether);
+        router.execute{value: 1 ether}(commands, inputs);
+        assertEq(weth.balanceOf(address(this)), 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- add `WrapETH.t.sol` foundry tests covering wrapETH success and insufficient balance cases
- record tested security scenarios in new `TestedVectors.md`

## Testing
- `forge test -vvv --match-path test/foundry-tests/UniversalRouter.t.sol`
- `forge test -vvv --match-path test/foundry-tests/Locker.t.sol`
- `forge test -vvv --match-path test/foundry-tests/MaxInputAmount.t.sol`
- `forge test -vvv --match-path test/foundry-tests/WrapETH.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_688926545928832d9748b80343d39b36