### PR TITLE
Document tested vectors and add allow revert regression

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,18 @@
+# Tested Attack Vectors
+
+This document tracks the attack vectors evaluated against the repository and the results of testing each vector.
+
+## 1. Allow Revert Flag Handling
+- **Vector**: Use the `FLAG_ALLOW_REVERT` with a command that fails internally (e.g. `PAY_PORTION` with invalid bips).
+- **Result**: Failing internal commands still revert the entire transaction instead of being ignored. Verified with `AllowRevert.t.sol` test which expects a revert when the flag is set.
+- **Status**: **Bug discovered** – the allow revert flag does not work for certain internal commands.
+
+## 2. Transient Storage Persistence
+- **Vector**: Reverting after calling functions that write to transient storage (e.g. `MaxInputAmount` or `Locker`) to see if the value persists and causes inconsistent state.
+- **Result**: Transient storage is cleared when the transaction reverts, so no state persists after failure.
+- **Status**: **Handled** – no persistent state was observed.
+
+## 3. Overflow in `BipsLibrary.calculatePortion`
+- **Vector**: Provide extremely large amounts to `calculatePortion` to test arithmetic overflow handling.
+- **Result**: Solidity 0.8 built‑in overflow checks correctly revert on overflow. No unexpected behaviour observed.
+- **Status**: **Handled** – library reverts as expected on overflow.

--- a/test/foundry-tests/AllowRevert.t.sol
+++ b/test/foundry-tests/AllowRevert.t.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {MockERC20} from './mock/MockERC20.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+
+contract AllowRevertTest is Test {
+    UniversalRouter router;
+    MockERC20 token;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+        token = new MockERC20();
+    }
+
+    function test_PayPortionAllowRevert() public {
+        token.mint(address(router), 1 ether);
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.PAY_PORTION) | uint8(Commands.FLAG_ALLOW_REVERT)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(token), address(1), 10001);
+        vm.expectRevert();
+        router.execute(commands, inputs);
+    }
+}


### PR DESCRIPTION
## Summary
- record tested attack vectors in new TestedVectors.md
- add foundry test showing allow-revert is ignored

## Testing
- `forge test --match-path test/foundry-tests/AllowRevert.t.sol`
- ❌ `yarn test:hardhat` *(fails: Infura API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_688926545928832d9748b80343d39b36