### PR TITLE
Add length mismatch test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,8 @@
+# Tested Attack Vectors
+
+This document tracks security related test cases executed against the code base.
+
+## 1. Mismatched Commands and Inputs
+- **Description**: Call `UniversalRouter.execute` with a commands array that does not match the length of the inputs array.
+- **Result**: The router reverted with the `LengthMismatch` custom error, preventing incorrect execution.
+- **Status**: Handled by the codebase.

--- a/test/foundry-tests/UniversalRouter.t.sol
+++ b/test/foundry-tests/UniversalRouter.t.sol
@@ -9,6 +9,7 @@ import {Commands} from '../../contracts/libraries/Commands.sol';
 import {MockERC20} from './mock/MockERC20.sol';
 import {ExampleModule} from '../../contracts/test/ExampleModule.sol';
 import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {IUniversalRouter} from '../../contracts/interfaces/IUniversalRouter.sol';
 import {ERC20} from 'solmate/src/tokens/ERC20.sol';
 import 'permit2/src/interfaces/IAllowanceTransfer.sol';
 import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
@@ -94,6 +95,14 @@ contract UniversalRouterTest is Test {
         erc20.mint(address(router), AMOUNT);
 
         vm.expectRevert(Payments.InsufficientETH.selector);
+        router.execute(commands, inputs);
+    }
+
+    function testLengthMismatch() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
+        bytes[] memory inputs = new bytes[](0);
+
+        vm.expectRevert(IUniversalRouter.LengthMismatch.selector);
         router.execute(commands, inputs);
     }
 }


### PR DESCRIPTION
## Summary
- add TestedVectors.md tracking tested attack vectors
- check execute() with mismatched inputs length and expect LengthMismatch

## Testing
- `forge test --match-test testLengthMismatch`
- `yarn lint:check`
- `forge fmt --check`


------
https://chatgpt.com/codex/tasks/task_e_688926569ebc832d8bb23ea0816b488c