### PR TITLE
Add forced ETH transfer test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -156,3 +156,9 @@ This document lists the attack vectors that have been tested against the Univers
   - **Vector**: Use a Uniswap v2 path with identical tokens such as `[WETH, WETH]`.
   - **Result**: The router attempts to access a non-existent pair and reverts with a generic error instead of `V2InvalidPath`.
   - **Bug?**: Yes. The router fails to validate identical-token paths.
+
+## Forced ETH via Self-Destruct
+- **Vector**: Send ETH to the router via a contract that self-destructs.
+- **Result**: ETH is received without calling `receive()` and the balance increases.
+- **Test**: `ForceETH.t.sol` self-destructs to the router and asserts the balance.
+- **Outcome**: Handled – forced transfers are possible but do not break router logic.

--- a/contracts/test/ForceETH.sol
+++ b/contracts/test/ForceETH.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+contract ForceETH {
+    constructor() payable {}
+
+    function destroy(address payable target) external {
+        selfdestruct(target);
+    }
+}

--- a/test/foundry-tests/ForceETH.t.sol
+++ b/test/foundry-tests/ForceETH.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {ForceETH} from '../../contracts/test/ForceETH.sol';
+
+contract ForceETHTest is Test {
+    UniversalRouter router;
+    ForceETH force;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+        force = new ForceETH{value: 1 ether}();
+    }
+
+    function testForceSendETH() public {
+        assertEq(address(router).balance, 0);
+        force.destroy(payable(address(router)));
+        assertEq(address(router).balance, 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- create `ForceETH` helper contract
- add `ForceETH.t.sol` to verify router can receive ETH via self-destruct
- document forced ETH vector in `TestedVectors.md`

## Testing
- `forge test --match-path test/foundry-tests/ForceETH.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688a966438b4832d9ff36bcca8a3e2fb