### PR TITLE
Add MSG_SENDER balance check test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -156,3 +156,8 @@ This document lists the attack vectors that have been tested against the Univers
   - **Vector**: Use a Uniswap v2 path with identical tokens such as `[WETH, WETH]`.
   - **Result**: The router attempts to access a non-existent pair and reverts with a generic error instead of `V2InvalidPath`.
   - **Bug?**: Yes. The router fails to validate identical-token paths.
+
+## Balance check using MSG_SENDER
+  - **Vector**: Call `BALANCE_CHECK_ERC20` with the owner argument set to the sentinel `MSG_SENDER`.
+  - **Result**: The router checks the balance of address `0x1` instead of the caller and reverts with `BalanceTooLow`.
+  - **Bug?**: Yes. The command does not map sentinel addresses and fails for valid callers.


### PR DESCRIPTION
## Summary
- add regression test showing BALANCE_CHECK_ERC20 fails when owner is MSG_SENDER
- document the bug in TestedVectors

## Testing
- `yarn test:hardhat` *(fails: HTTP 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_688a966438b4832d9ff36bcca8a3e2fb