### PR TITLE
Add MaxInputAmount revert test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -192,6 +192,11 @@ This document lists the attack vectors that have been tested against the Univers
   - **Result**: The second swap succeeds, demonstrating the `MaxInputAmount` transient storage was cleared when the first call reverted.
   - **Status**: Handled – reverting a swap does not leave stale values in transient storage.
 
+## MaxInputAmount revert before clearing
+  - **Vector**: Trigger a revert inside `V3_SWAP_EXACT_OUT` before the call resets `MaxInputAmount`.
+  - **Result**: `MaxInputAmountRouterReset.t.sol` shows the value is zero after the revert, so the storage does not persist.
+  - **Status**: Handled – the transient slot is cleared on failure.
+
 
 ## Balance check using ADDRESS_THIS
   - **Vector**: Call `BALANCE_CHECK_ERC20` with the owner argument set to the sentinel `ADDRESS_THIS`.

--- a/contracts/test/harness/V3ExactOutputRevertHarness.sol
+++ b/contracts/test/harness/V3ExactOutputRevertHarness.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {V3SwapRouter} from "../../modules/uniswap/v3/V3SwapRouter.sol";
+import {Permit2Payments} from "../../modules/Permit2Payments.sol";
+import {PaymentsImmutables, PaymentsParameters} from "../../modules/PaymentsImmutables.sol";
+import {UniswapImmutables, UniswapParameters} from "../../modules/uniswap/UniswapImmutables.sol";
+import {MaxInputAmount} from "../../libraries/MaxInputAmount.sol";
+
+contract V3ExactOutputRevertHarness is V3SwapRouter {
+    constructor()
+        UniswapImmutables(UniswapParameters(address(0), address(0), bytes32(0), bytes32(0)))
+        PaymentsImmutables(PaymentsParameters(address(0), address(0)))
+    {}
+
+    function callExactOutRevert(bytes calldata path) external {
+        v3SwapExactOutput(address(this), 1 ether, 1 ether, path, address(this));
+    }
+
+    function getMaxInput() external view returns (uint256) {
+        return MaxInputAmount.get();
+    }
+}

--- a/test/foundry-tests/MaxInputAmountRouterReset.t.sol
+++ b/test/foundry-tests/MaxInputAmountRouterReset.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {V3ExactOutputRevertHarness} from "../../contracts/test/harness/V3ExactOutputRevertHarness.sol";
+
+contract MaxInputAmountRouterResetTest is Test {
+    V3ExactOutputRevertHarness harness;
+
+    function setUp() public {
+        harness = new V3ExactOutputRevertHarness();
+    }
+
+    function testRevertClearsMaxInput() public {
+        bytes memory path = abi.encodePacked(address(1), uint24(500), address(2));
+        vm.expectRevert();
+        harness.callExactOutRevert(path);
+        assertEq(harness.getMaxInput(), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add harness to trigger V3 exact output revert
- test that MaxInputAmount transient storage is cleared on failure
- document this new test in TestedVectors

## Testing
- `forge test --match-contract MaxInputAmountRouterResetTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688c13cfb114832da41941402efe0675