### PR TITLE
Add test for V4 position manager ETH forwarding

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -202,3 +202,8 @@ This document lists the attack vectors that have been tested against the Univers
   - **Vector**: Call `BALANCE_CHECK_ERC20` with the owner argument set to the sentinel `ADDRESS_THIS`.
   - **Result**: The router checks the balance of address `0x2` rather than its own address and reverts with `BalanceTooLow`.
   - **Bug?**: Yes. The command fails to map the `ADDRESS_THIS` sentinel to `address(this)`.
+
+## V4 Position Manager call forwards entire ETH balance
+  - **Vector**: Force ETH into the router and invoke `V4_POSITION_MANAGER_CALL` with a basic `modifyLiquidities` call.
+  - **Result**: The router forwarded all ETH it held to the position manager, demonstrating the entire balance is sent.
+  - **Status**: Handled – behaviour confirmed in `V4PositionManagerValue.t.sol` but may be unexpected.

--- a/test/foundry-tests/V4PositionManagerValue.t.sol
+++ b/test/foundry-tests/V4PositionManagerValue.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+import {ForceETH} from "../../contracts/test/ForceETH.sol";
+import {MockV4PositionManager} from "./mock/MockV4PositionManager.sol";
+
+contract V4PositionManagerValueTest is Test {
+    UniversalRouter router;
+    MockV4PositionManager manager;
+    ForceETH force;
+
+    function setUp() public {
+        manager = new MockV4PositionManager();
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(manager)
+        });
+        router = new UniversalRouter(params);
+        force = new ForceETH{value: 1 ether}();
+    }
+
+    function testForwardsEntireBalance() public {
+        // force 1 ether into the router
+        force.destroy(payable(address(router)));
+        assertEq(address(router).balance, 1 ether, "router should hold ETH");
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V4_POSITION_MANAGER_CALL)));
+        bytes[] memory inputs = new bytes[](1);
+        bytes[] memory params = new bytes[](1);
+        params[0] = abi.encode(address(0), address(this));
+        bytes memory unlockData = abi.encode(hex"14", params);
+        inputs[0] = abi.encodeWithSelector(manager.modifyLiquidities.selector, unlockData, uint256(0));
+
+        router.execute(commands, inputs);
+
+        assertEq(manager.lastValue(), 1 ether, "manager received all ETH");
+        assertEq(address(router).balance, 0, "router balance drained");
+    }
+}

--- a/test/foundry-tests/mock/MockV4PositionManager.sol
+++ b/test/foundry-tests/mock/MockV4PositionManager.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+contract MockV4PositionManager {
+    uint256 public lastValue;
+    bytes public lastUnlockData;
+    uint256 public lastDeadline;
+
+    function modifyLiquidities(bytes calldata unlockData, uint256 deadline) external payable {
+        lastValue = msg.value;
+        lastUnlockData = unlockData;
+        lastDeadline = deadline;
+    }
+}


### PR DESCRIPTION
## Summary
- add mock V4 position manager contract
- add test demonstrating that V4_POSITION_MANAGER_CALL forwards the router's entire ETH balance
- record the attack vector in TestedVectors.md

## Testing
- `forge test --match-contract V4PositionManagerValueTest -vv`

------
https://chatgpt.com/codex/tasks/task_e_688cc5bfa0c8832da8e8d6672c043926