### PR TITLE
Add test for ETH sent with no commands

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -217,3 +217,8 @@ This document lists the attack vectors that have been tested against the Univers
   - **Vector**: Use an ERC20 token whose `transfer` function reenters the router during a `TRANSFER` command.
   - **Result**: The reentrant call is rejected with `ContractLocked` and the token transaction reverts.
   - **Status**: Handled – the router's lock prevents reentrancy during ERC20 transfers.
+## ETH Sent with Empty Commands
+- **Vector**: Call `execute` with no commands but send ETH in the transaction.
+- **Result**: The ETH remains in the router and can be swept by any address using the `SWEEP` command.
+- **Status**: Handled – funds are not automatically returned but are withdrawable by anyone.
+

--- a/test/foundry-tests/EmptyCommands.t.sol
+++ b/test/foundry-tests/EmptyCommands.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+import {Constants} from "../../contracts/libraries/Constants.sol";
+
+contract EmptyCommandsTest is Test {
+    UniversalRouter router;
+
+    receive() external payable {}
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function testEmptyCommandsLeavesEthBalance() public {
+        router.execute{value: 1 ether}(hex"", new bytes[](0));
+        assertEq(address(router).balance, 1 ether);
+    }
+
+    function testAnyoneCanSweepRemainingEth() public {
+        router.execute{value: 1 ether}(hex"", new bytes[](0));
+        uint256 start = address(this).balance;
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(Constants.ETH, address(this), 0);
+        router.execute(commands, inputs);
+        assertEq(address(this).balance - start, 1 ether);
+        assertEq(address(router).balance, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EmptyCommands.t.sol` foundry test
- document vector about sending ETH with empty commands in `TestedVectors.md`

## Testing
- `forge test --match-path test/foundry-tests/EmptyCommands.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_688cfac117b8832d8e987e9892519e7b