### PR TITLE
Add reserved address wrap test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -84,9 +84,14 @@ This document lists the attack vectors that have been tested against the Univers
 
 
 ## Transfer to reserved addresses
-- **Vector:** Attempt to transfer ERC20 tokens to address `0x0000000000000000000000000000000000000001` via the router.
-- **Finding:** Tokens are incorrectly sent to the caller instead of the intended address. This occurs because the router maps address `1` to `MSG_SENDER`.
-- **Test:** `testTransferToReservedAddress` in `test/foundry-tests/UniversalRouter.t.sol` demonstrates the issue.
+  - **Vector:** Attempt to transfer ERC20 tokens to address `0x0000000000000000000000000000000000000001` via the router.
+  - **Finding:** Tokens are incorrectly sent to the caller instead of the intended address. This occurs because the router maps address `1` to `MSG_SENDER`.
+  - **Test:** `testTransferToReservedAddress` in `test/foundry-tests/UniversalRouter.t.sol` demonstrates the issue.
+
+## WrapETH to reserved address
+  - **Vector:** Call `WRAP_ETH` with the recipient set to `0x0000000000000000000000000000000000000002`.
+  - **Finding:** The router treats address `2` as `ADDRESS_THIS`, so the wrapped ETH remains with the router instead of being sent to the target address.
+  - **Test:** `WrapETHReservedAddressTest` shows the WETH balance is credited to the router.
 
 
 ## Looping V2 swap path**: Crafted a path where the last hop returns to the first token (e.g. `[token0, token1, token0]`).

--- a/test/foundry-tests/WrapETHReservedAddress.t.sol
+++ b/test/foundry-tests/WrapETHReservedAddress.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {ActionConstants} from '@uniswap/v4-periphery/src/libraries/ActionConstants.sol';
+import {WETH} from 'lib/permit2/lib/solmate/src/tokens/WETH.sol';
+
+contract WrapETHReservedAddressTest is Test {
+    UniversalRouter router;
+    WETH weth;
+
+    function setUp() public {
+        weth = new WETH();
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(weth),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function testWrapETHToReservedAddress() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.WRAP_ETH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(2), 1 ether);
+
+        router.execute{value: 1 ether}(commands, inputs);
+
+        assertEq(weth.balanceOf(address(2)), 0);
+        assertEq(weth.balanceOf(address(router)), 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- add WrapETHReservedAddressTest to show reserved address mapping
- document new vector in TestedVectors

## Testing
- `forge test --match-contract WrapETHReservedAddressTest -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d039a034c832da73d905f9bdb9a5c