### PR TITLE
Add deadline bypass test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -237,4 +237,7 @@ This document lists the attack vectors that have been tested against the Univers
 ## Nonexistent V2 pair
   - **Vector**: Attempt a V2 swap using tokens that do not have an existing pair.
   - **Result**: The router transfers tokens to the computed pair address and then reverts when calling `getReserves`, leaving the funds stuck.
-  - **Bug?**: Yes. Pair existence is not checked before transferring funds.
+  - **Bug?**: Yes. Pair existence is not checked before transferring funds.\n## Execute Without Deadline
+- **Vector**: Call the overloaded `execute` function without a deadline.
+- **Result**: The transaction succeeds even when a past deadline would cause the other overload to revert.
+- **Status**: Handled – the router provides a no-deadline overload intentionally.

--- a/test/foundry-tests/DeadlineBypass.t.sol
+++ b/test/foundry-tests/DeadlineBypass.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {IUniversalRouter} from "../../contracts/interfaces/IUniversalRouter.sol";
+
+contract DeadlineBypassTest is Test {
+    UniversalRouter router;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function testDeadlineEnforced() public {
+        bytes memory commands = hex"";
+        bytes[] memory inputs = new bytes[](0);
+        vm.warp(1000);
+        vm.expectRevert(IUniversalRouter.TransactionDeadlinePassed.selector);
+        router.execute(commands, inputs, 999);
+    }
+
+    function testExecuteWithoutDeadlineSucceeds() public {
+        bytes memory commands = hex"";
+        bytes[] memory inputs = new bytes[](0);
+        vm.warp(1000);
+        router.execute(commands, inputs);
+    }
+}


### PR DESCRIPTION
## Summary
- add DeadlineBypass test checking that the router enforces deadlines only on the overloaded execute
- document the vector in TestedVectors

## Testing
- `forge test --match-contract DeadlineBypassTest -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d039a034c832da73d905f9bdb9a5c