### PR TITLE
Add unwrapWETH reserved address test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -93,6 +93,11 @@ This document lists the attack vectors that have been tested against the Univers
   - **Finding:** The router treats address `2` as `ADDRESS_THIS`, so the wrapped ETH remains with the router instead of being sent to the target address.
   - **Test:** `WrapETHReservedAddressTest` shows the WETH balance is credited to the router.
 
+## UnwrapWETH to reserved address
+  - **Vector:** Call `UNWRAP_WETH` with the recipient set to `0x0000000000000000000000000000000000000002`.
+  - **Finding:** The router interprets address `2` as `ADDRESS_THIS`, leaving the unwrapped ETH in the router.
+  - **Test:** `UnwrapWETHReservedAddressTest` demonstrates the ETH remains with the router after unwrapping.
+
 
 ## Looping V2 swap path**: Crafted a path where the last hop returns to the first token (e.g. `[token0, token1, token0]`).
   - **Result**: Transaction reverts with `UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT` showing Universal Router does not gracefully handle looping paths.

--- a/test/foundry-tests/UnwrapWETHReservedAddress.t.sol
+++ b/test/foundry-tests/UnwrapWETHReservedAddress.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {ActionConstants} from '@uniswap/v4-periphery/src/libraries/ActionConstants.sol';
+import {WETH} from 'lib/permit2/lib/solmate/src/tokens/WETH.sol';
+
+contract UnwrapWETHReservedAddressTest is Test {
+    UniversalRouter router;
+    WETH weth;
+
+    function setUp() public {
+        weth = new WETH();
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(weth),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+        weth.deposit{value: 1 ether}();
+        weth.transfer(address(router), 1 ether);
+    }
+
+    function testUnwrapWETHToReservedAddress() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.UNWRAP_WETH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(2), 0);
+
+        router.execute(commands, inputs);
+
+        assertEq(address(router).balance, 1 ether, 'ETH stays in router');
+        assertEq(weth.balanceOf(address(router)), 0, 'WETH burned');
+    }
+}


### PR DESCRIPTION
## Summary
- add test ensuring UNWRAP_WETH with reserved address keeps ETH in the router
- document this vector in TestedVectors

## Testing
- `forge test -vv --match-path test/foundry-tests/UnwrapWETHReservedAddress.t.sol`

------
https://chatgpt.com/codex/tasks/task_e_688d116587b4832d8adb1880b38bfad2