### PR TITLE
Add Sweep reserved address test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -98,6 +98,12 @@ This document lists the attack vectors that have been tested against the Univers
   - **Finding:** The router interprets address `2` as `ADDRESS_THIS`, leaving the unwrapped ETH in the router.
   - **Test:** `UnwrapWETHReservedAddressTest` demonstrates the ETH remains with the router after unwrapping.
 
+## Sweep to reserved address
+  - **Vector:** Call `SWEEP` with the recipient set to `0x0000000000000000000000000000000000000001`.
+  - **Finding:** The router maps address `1` to `MSG_SENDER`, so the swept tokens go to the caller instead of the target address.
+  - **Test:** `SweepReservedAddressTest` verifies tokens are sent to the caller.
+
+
 
 ## Looping V2 swap path**: Crafted a path where the last hop returns to the first token (e.g. `[token0, token1, token0]`).
   - **Result**: Transaction reverts with `UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT` showing Universal Router does not gracefully handle looping paths.

--- a/test/foundry-tests/SweepReservedAddress.t.sol
+++ b/test/foundry-tests/SweepReservedAddress.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+import {MockERC20} from "./mock/MockERC20.sol";
+
+contract SweepReservedAddressTest is Test {
+    UniversalRouter router;
+    MockERC20 token;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+        token = new MockERC20();
+        token.mint(address(router), 1 ether);
+    }
+
+    function testSweepToReservedAddressSendsToCaller() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(token), address(1), 0);
+
+        router.execute(commands, inputs);
+
+        assertEq(token.balanceOf(address(1)), 0, "tokens not sent to reserved address");
+        assertEq(token.balanceOf(address(this)), 1 ether, "caller received tokens");
+        assertEq(token.balanceOf(address(router)), 0, "router balance cleared");
+    }
+}


### PR DESCRIPTION
## Summary
- add foundry test SweepReservedAddressTest
- document sweep to reserved address vector

## Testing
- `forge test --match-contract SweepReservedAddressTest`

------
https://chatgpt.com/codex/tasks/task_e_688d2d5f3630832dace9a29b0852ca5e