### PR TITLE
Add Unwrap WETH insufficient balance test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -277,3 +277,7 @@ This document lists the attack vectors that have been tested against the Univers
   - **Vector**: Construct commands that repeatedly call `EXECUTE_SUB_PLAN` creating a deeply nested plan.
   - **Result**: The transaction eventually reverts with an out-of-gas error once recursion depth grows large, preventing further execution.
   - **Status**: **Handled** – recursion is limited by EVM gas and call depth so no funds are lost.
+## Unwrap WETH with insufficient balance
+- **Vector**: Call `UNWRAP_WETH` when the router holds less WETH than the `amountMinimum` argument.
+- **Result**: The call reverts with `InsufficientETH`, proving the router checks its WETH balance before unwrapping.
+- **Status**: Handled – the router prevents unwrapping when funds are insufficient.

--- a/test/foundry-tests/UnwrapWETHInsufficientBalance.t.sol
+++ b/test/foundry-tests/UnwrapWETHInsufficientBalance.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+import {Payments} from "../../contracts/modules/Payments.sol";
+import {WETH} from "lib/permit2/lib/solmate/src/tokens/WETH.sol";
+
+contract UnwrapWETHInsufficientBalanceTest is Test {
+    UniversalRouter router;
+    WETH weth;
+
+    function setUp() public {
+        weth = new WETH();
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(weth),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function testUnwrapWETHInsufficientBalance() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.UNWRAP_WETH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(this), 1 ether);
+
+        vm.expectRevert(Payments.InsufficientETH.selector);
+        router.execute(commands, inputs);
+    }
+}


### PR DESCRIPTION
## Summary
- add a foundry test ensuring `UNWRAP_WETH` reverts when the router has no WETH
- document the attack vector in TestedVectors.md

## Testing
- `forge test` *(fails: missing `FORK_URL` for some tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d2d5f3630832dace9a29b0852ca5e