### PR TITLE
Add test for truncated inputs

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -297,3 +297,8 @@ This document lists the attack vectors that have been tested against the Univers
 - **Vector**: Call `UNWRAP_WETH` when the router holds less WETH than the `amountMinimum` argument.
 - **Result**: The call reverts with `InsufficientETH`, proving the router checks its WETH balance before unwrapping.
 - **Status**: Handled – the router prevents unwrapping when funds are insufficient.
+
+## Truncated command input
+- **Vector**: Provide input data shorter than expected for the `TRANSFER` command.
+- **Result**: The router executed without reverting, treating missing parameters as zero and leaving balances unchanged.
+- **Status**: Handled – short inputs are ignored without affecting state.

--- a/test/foundry-tests/ShortInput.t.sol
+++ b/test/foundry-tests/ShortInput.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+import {MockERC20} from "./mock/MockERC20.sol";
+
+contract ShortInputTest is Test {
+    UniversalRouter router;
+    MockERC20 token;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+        token = new MockERC20();
+        token.mint(address(router), 1 ether);
+    }
+
+    function testShortInputDoesNothing() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.TRANSFER)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(token)); // missing recipient and amount
+
+        router.execute(commands, inputs);
+
+        assertEq(token.balanceOf(address(router)), 1 ether, "router token balance changed");
+    }
+}


### PR DESCRIPTION
## Summary
- add ShortInput test to verify short command handling
- document the vector in TestedVectors

## Testing
- `forge test --match-path test/foundry-tests/ShortInput.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d388b45d0832dad23218089ae606a