### PR TITLE
Add test for extra ETH in WRAP_ETH and document bug

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -234,6 +234,11 @@ This document lists the attack vectors that have been tested against the Univers
   - **Result**: The router wraps all ETH it holds, including the forced funds, and transfers WETH to the caller.
   - **Status**: Handled – forced ETH can be withdrawn but no user funds are at risk.
 
+## WrapETH with excess `msg.value`
+  - **Vector**: Send more ETH with the transaction than the `WRAP_ETH` command amount specifies.
+  - **Result**: Only the requested amount is wrapped. The surplus ETH remains in the router and can later be swept by anyone.
+  - **Status**: **Bug discovered** – excess ETH is not refunded to the caller.
+
 ## V4 Position Manager call forwards entire ETH balance
   - **Vector**: Force ETH into the router and invoke `V4_POSITION_MANAGER_CALL` with a basic `modifyLiquidities` call.
   - **Result**: The router forwarded all ETH it held to the position manager, demonstrating the entire balance is sent.

--- a/test/foundry-tests/WrapETHExcessValue.t.sol
+++ b/test/foundry-tests/WrapETHExcessValue.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {WETH} from 'lib/permit2/lib/solmate/src/tokens/WETH.sol';
+
+contract WrapETHExcessValueTest is Test {
+    UniversalRouter router;
+    WETH weth;
+
+    function setUp() public {
+        weth = new WETH();
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(weth),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function testWrapETHLeavesExcessValue() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.WRAP_ETH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(this), 1 ether);
+
+        router.execute{value: 2 ether}(commands, inputs);
+
+        assertEq(weth.balanceOf(address(this)), 1 ether, 'should wrap requested amount');
+        assertEq(address(router).balance, 1 ether, 'excess ETH remains in router');
+    }
+}


### PR DESCRIPTION
## Summary
- explore WRAP_ETH handling of excess msg.value
- document the newly found vector in TestedVectors

## Testing
- `forge test --match-path test/foundry-tests/WrapETHExcessValue.t.sol -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688d388b45d0832dad23218089ae606a