### PR TITLE
Add PayPortion reserved address test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -103,6 +103,11 @@ This document lists the attack vectors that have been tested against the Univers
   - **Finding:** The router maps address `1` to `MSG_SENDER`, so the swept tokens go to the caller instead of the target address.
   - **Test:** `SweepReservedAddressTest` verifies tokens are sent to the caller.
 
+## PayPortion to reserved address
+  - **Vector:** Call `PAY_PORTION` with the recipient set to `0x0000000000000000000000000000000000000001` or `0x0000000000000000000000000000000000000002`.
+  - **Finding:** The router interprets these addresses as `MSG_SENDER` or `ADDRESS_THIS`, leaving funds with the caller or router instead of the intended address.
+  - **Test:** `PayPortionReservedAddress.t.sol` demonstrates tokens are misdirected.
+
 
 
 ## Looping V2 swap path**: Crafted a path where the last hop returns to the first token (e.g. `[token0, token1, token0]`).

--- a/test/foundry-tests/PayPortionReservedAddress.t.sol
+++ b/test/foundry-tests/PayPortionReservedAddress.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {UniversalRouter} from "../../contracts/UniversalRouter.sol";
+import {RouterParameters} from "../../contracts/types/RouterParameters.sol";
+import {MockERC20} from "./mock/MockERC20.sol";
+import {Commands} from "../../contracts/libraries/Commands.sol";
+
+contract PayPortionReservedAddressTest is Test {
+    UniversalRouter router;
+    MockERC20 token;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0)
+        });
+        router = new UniversalRouter(params);
+        token = new MockERC20();
+        token.mint(address(router), 100 ether);
+    }
+
+    function testPayPortionToReservedAddressTwoKeepsTokens() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.PAY_PORTION)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(token), address(2), 5_000); // 50%
+
+        router.execute(commands, inputs);
+
+        assertEq(token.balanceOf(address(2)), 0, "target did not receive tokens");
+        assertEq(token.balanceOf(address(router)), 100 ether, "router balance unchanged");
+    }
+
+    function testPayPortionToReservedAddressOneSendsToCaller() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.PAY_PORTION)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(token), address(1), 5_000); // 50%
+
+        router.execute(commands, inputs);
+
+        assertEq(token.balanceOf(address(this)), 50 ether, "caller received tokens");
+        assertEq(token.balanceOf(address(router)), 50 ether, "router balance reduced");
+        assertEq(token.balanceOf(address(1)), 0, "reserved address received none");
+    }
+}


### PR DESCRIPTION
## Summary
- add Foundry test `PayPortionReservedAddressTest` demonstrating misdirected funds
- document the new vector in `TestedVectors.md`

## Testing
- `forge test --match-contract PayPortionReservedAddressTest`

------
https://chatgpt.com/codex/tasks/task_e_688d40ed7d8c832dba1ccfa2d4b4c80f